### PR TITLE
Update validation method for statuses

### DIFF
--- a/chapter2/4_end_to_end_tests/1_http_api_tests/server.test.js
+++ b/chapter2/4_end_to_end_tests/1_http_api_tests/server.test.js
@@ -15,7 +15,7 @@ const getItems = username => {
 
 test("adding items to a cart", async () => {
   const initialItemsResponse = await getItems("lucas");
-  expect(initialItemsResponse.status).toEqual(404);
+  expect(initialItemsResponse.status).toBe(404);
 
   const addItemResponse = await addItem("lucas", "cheesecake");
   expect(await addItemResponse.json()).toEqual(["cheesecake"]);


### PR DESCRIPTION
It uses `toBe` instead of `toEqual`.