### PR TITLE
Add assertion to check inventory and update addItemToCart function to pass

### DIFF
--- a/chapter4/1_setting_up_a_test_environment/1_exposing_modules/3_unit_tests/cartController.js
+++ b/chapter4/1_setting_up_a_test_environment/1_exposing_modules/3_unit_tests/cartController.js
@@ -1,4 +1,4 @@
-const { removeFromInventory } = require("./inventoryController");
+const { inventory, removeFromInventory } = require("./inventoryController");
 const logger = require("./logger");
 
 const carts = new Map();
@@ -8,6 +8,7 @@ const addItemToCart = (username, item) => {
   const newItems = (carts.get(username) || []).concat(item);
 
   if (!compliesToItemLimit(newItems)) {
+    inventory.set(item, inventory.get(item) + 1);
     const limitError = new Error(
       "You can't have more than three units of an item in your cart"
     );

--- a/chapter4/1_setting_up_a_test_environment/1_exposing_modules/3_unit_tests/cartController.test.js
+++ b/chapter4/1_setting_up_a_test_environment/1_exposing_modules/3_unit_tests/cartController.test.js
@@ -47,7 +47,8 @@ describe("addItemToCart", () => {
     }
 
     expect(carts.get("test_user")).toEqual(initialCartContent);
-    expect.assertions(2);
+    expect(inventory.get('cheesecake')).toEqual(1);
+    expect.assertions(3);
   });
 
   test("logging added items", () => {


### PR DESCRIPTION
This pull request is based upon the following prompt from section 4.1.3 in the book: "As an exercise, try integrating this function [compliesToItemLimit] into addItemToCart and writing integration and end-to-end tests to validate this behavior."

In the current code implementation, adding an item to a user's cart when they already have three of those items in their cart correctly throws an error. But the item has already been removed from the inventory and it is not re-added to inventory before the function exits.

This bug can be verified by adding the following assertion to cartController.test.js:
`expect(inventory.get('cheesecake')).toEqual(1);`