### PR TITLE
Fixed an issue in chapter 6 where window repeatedly listened to popstate event.

### DIFF
--- a/chapter6/4_testing_and_browser_apis/2_history_api/main.test.js
+++ b/chapter6/4_testing_and_browser_apis/2_history_api/main.test.js
@@ -11,17 +11,14 @@ beforeEach(() => localStorage.clear());
 beforeEach(() => {
   document.body.innerHTML = initialHtml;
 
+  jest.spyOn(window, "addEventListener");
+
   // You must execute main.js again so that it can attach the
   // event listener to the form every time the body changes.
   // Here you must use `jest.resetModules` because otherwise
   // Jest will have cached `main.js` and it will _not_ run again.
   jest.resetModules();
-  require("./main");
-
-  // You can only spy on `window.addEventListener` after `main.js`
-  // has been executed. Otherwise `detachPopstateHandlers` will
-  // also detach the handlers that `main.js` attached to the page.
-  jest.spyOn(window, "addEventListener");
+  require("./main");  
 });
 
 afterEach(detachPopstateHandlers);

--- a/chapter6/5_web_sockets_and_http_requests/1_http_requests/main.test.js
+++ b/chapter6/5_web_sockets_and_http_requests/1_http_requests/main.test.js
@@ -13,6 +13,8 @@ beforeEach(() => localStorage.clear());
 beforeEach(async () => {
   document.body.innerHTML = initialHtml;
 
+  jest.spyOn(window, "addEventListener");
+
   // You must execute main.js again so that it can attach the
   // event listener to the form every time the body changes.
   // Here you must use `jest.resetModules` because otherwise
@@ -22,12 +24,7 @@ beforeEach(async () => {
   nock(API_ADDR)
     .get("/inventory")
     .replyWithError({ code: 500 });
-  await require("./main");
-
-  // You can only spy on `window.addEventListener` after `main.js`
-  // has been executed. Otherwise `detachPopstateHandlers` will
-  // also detach the handlers that `main.js` attached to the page.
-  jest.spyOn(window, "addEventListener");
+  await require("./main");  
 });
 
 afterEach(detachPopstateHandlers);

--- a/chapter6/5_web_sockets_and_http_requests/2_web_sockets/main.test.js
+++ b/chapter6/5_web_sockets_and_http_requests/2_web_sockets/main.test.js
@@ -13,6 +13,8 @@ beforeEach(() => localStorage.clear());
 beforeEach(async () => {
   document.body.innerHTML = initialHtml;
 
+  jest.spyOn(window, "addEventListener");
+
   // You must execute main.js again so that it can attach the
   // event listener to the form every time the body changes.
   // Here you must use `jest.resetModules` because otherwise
@@ -22,12 +24,7 @@ beforeEach(async () => {
   nock(API_ADDR)
     .get("/inventory")
     .replyWithError({ code: 500 });
-  await require("./main");
-
-  // You can only spy on `window.addEventListener` after `main.js`
-  // has been executed. Otherwise `detachPopstateHandlers` will
-  // also detach the handlers that `main.js` attached to the page.
-  jest.spyOn(window, "addEventListener");
+  await require("./main");  
 });
 
 afterEach(detachPopstateHandlers);


### PR DESCRIPTION
In the section 6.4.2 of the book it is written: 

> When using detachPopstateHandlers in main.test.js, you must be careful when detaching all of the window’s listeners after each test, because, otherwise, the listener attached by main.js can accidentally be detached, too. To avoid removing the listeners attached by main.js, make sure that you spy on window.addEventListener only after executing main.js

The current code looks like this:
```js
beforeEach(() => {
  document.body.innerHTML = initialHtml;

  // You must execute main.js again so that it can attach the
  // event listener to the form every time the body changes.
  // Here you must use `jest.resetModules` because otherwise
  // Jest will have cached `main.js` and it will _not_ run again.
  jest.resetModules();
  require("./main");

  // You can only spy on `window.addEventListener` after `main.js`
  // has been executed. Otherwise `detachPopstateHandlers` will
  // also detach the handlers that `main.js` attached to the page.
  jest.spyOn(window, "addEventListener");
});

afterEach(detachPopstateHandlers);
```

But this is a bit strange, currently `detachPopstateHandlers` will only detach the popstate event registered in the test, but each time `beforeEach` will re-execute `main.js` so the window will also register the popstate event again but without first removing the previous registration? So I think we should spy on `window.addEvenetListener` **before** `main.js` has been executed.

I wrote a [test](https://github.com/cxc421/testing-javascript-applications/commit/359bbe243468659abc0b7884cd1f483caeb8c58f) based on the current implementation to verify this problem, this program simply prints out where popstate event is triggered, and after execution, it can be found that window has registered the popstate event multiple times.