### PR TITLE
close  db connection pool before expect function

### DIFF
--- a/chapter2/3_integration_tests/1_knex_tests_promise/cart.test.js
+++ b/chapter2/3_integration_tests/1_knex_tests_promise/cart.test.js
@@ -5,6 +5,6 @@ test("createCart creates a cart for a username", async () => {
   await db("carts").truncate();
   await createCart("Lucas da Costa");
   const result = await db.select("username").from("carts");
-  expect(result).toEqual([{ username: "Lucas da Costa" }]);
   await closeConnection();
+  expect(result).toEqual([{ username: "Lucas da Costa" }]);
 });


### PR DESCRIPTION
Closing the db connection after the 'expect' function will cause the program not terminating if the test failed